### PR TITLE
Fixed saving issue for Cluck!

### DIFF
--- a/src/main/java/cluck/Cluck.java
+++ b/src/main/java/cluck/Cluck.java
@@ -24,20 +24,19 @@ public class Cluck {
      * Instantiates a new Cluck with no arguments for JavaFx Application use.
      */
     public Cluck() {
-        this.taskList = new TaskList();
         this.storage = new Storage("/data/cluckSave.txt");
+        this.taskList = storage.readSave();
 
     }
 
     /**
-     * Cluck class contains and instance of TaskList, Ui, and Storage.
-     * These classes are the building blocks of Cluck.
+     * Instantiates a Cluck class that will store the data in the given file path.
      *
      * @param filePath path of saved path as String
      */
     public Cluck(String filePath) {
         this.storage = new Storage(filePath);
-
+        this.taskList = storage.readSave();
     }
 
     /**
@@ -54,16 +53,19 @@ public class Cluck {
         }
         storage.writetoSave(taskList);
     }
+
     private Command getCommand(String userInput) throws CluckException {
         assert Objects.nonNull(userInput);
         return Parser.commandFactory(userInput);
     }
+
     private String executeCommand(Command command) throws CluckException {
         if (command instanceof ExitCommand) {
             isRunning = false;
         }
         return command.execute(taskList, storage);
     }
+
     /**
      * Gets response.
      *

--- a/src/main/java/cluck/storage/Storage.java
+++ b/src/main/java/cluck/storage/Storage.java
@@ -1,7 +1,6 @@
 package cluck.storage;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -17,42 +16,59 @@ import cluck.tasks.Task;
  * Storage class handles the reading and writing of saved tasks in a given .txt file.
  */
 public class Storage {
+
+    private String directory;
+    private Path filePath;
     private File saveFile;
+    private File saveDir;
+
 
     /**
      * Instantiates a new Storage.
      *
      * @param filePath the file path of the saved tasks
      */
-
-    private String home = System.getProperty("user.home");
-    private Path filePath;
-
     public Storage(String filePath) {
-        this.filePath = Paths.get(home, "data", filePath);
 
-        // Create tasks file if it doesn't exist
-        saveFile = new File(this.filePath.toString());
-        if (!saveFile.exists()) {
+        this.directory = System.getProperty("user.dir");
+        this.filePath = Paths.get(directory, filePath);
+        this.saveFile = this.filePath.toFile();
+        this.saveDir = this.saveFile.getParentFile();
+
+        if (!this.saveDir.exists()) {
+            this.saveDir.mkdir();
+        }
+        if (!this.saveFile.exists()) {
             try {
-                saveFile.createNewFile();
-            } catch (Exception e) {
-                System.out.println("Crapadoodle! I couldn't create a new file. Something went wrong.");
+                this.saveFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }
 
-    private TaskList populateTaskList(TaskList taskList) {
+    /**
+     * Reads saved file at save location, returns a task list class containing the saved tasks.
+     * If the file does not exist, the method returns an empty task list
+     *
+     * @return task list containing saved tasks or empty task list
+     */
+    public TaskList readSave() {
         Scanner savedFileScanner;
         try {
-            savedFileScanner = new Scanner(saveFile);
-            saveFile.createNewFile();
+            savedFileScanner = new Scanner(this.saveFile);
         } catch (Exception e) {
             e.printStackTrace();
             return new TaskList();
         }
+        return this.populateTaskList(savedFileScanner);
+    }
+
+    private TaskList populateTaskList(Scanner savedFileScanner) {
         String taskString;
         Task currTask;
+        TaskList taskList = new TaskList();
+
         while (savedFileScanner.hasNextLine()) {
             taskString = savedFileScanner.nextLine();
             try {

--- a/src/test/java/cluck/task/TaskTest.java
+++ b/src/test/java/cluck/task/TaskTest.java
@@ -1,12 +1,10 @@
 package cluck.task;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import cluck.tasks.Deadline;
-import cluck.tasks.Event;
+import org.junit.jupiter.api.Test;
+
 import cluck.tasks.Task;
 import cluck.tasks.ToDo;
 
@@ -18,6 +16,7 @@ public class TaskTest {
         Task savedTask = Task.buildTaskFromSave(workingTodoSave);
         Task testTask = new ToDo("Meet Jason");
         assertEquals(savedTask, testTask);
+
     }
 
     @Test


### PR DESCRIPTION
Previously Cluck! was unable to create a directory and text file to save the user's tasks. 

Now Cluck! can do that. Hooray!

This was done by fixing the Storage class. The previous code mistakenly took the user's home directory and tried to create a file there. Also, the parent directory for the data file was a a little messy. I'm honestly not entirely sure what was the fix because I could have sworn I did the exact same thing previously and it didn't work, might have been the mkdirs() method (thanks java). 